### PR TITLE
use PLATFORM.moduleName to fix bundling with webpack

### DIFF
--- a/dist/amd/configuration.js
+++ b/dist/amd/configuration.js
@@ -1,6 +1,7 @@
 define(["require", "exports"], function (require, exports) {
     "use strict";
-    var ConfigurationBuilderImpl = (function () {
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var ConfigurationBuilderImpl = /** @class */ (function () {
         function ConfigurationBuilderImpl() {
             this.doTrackLogs = false;
             this.doTrackGlobalErrors = false;

--- a/dist/amd/debug-telemetry-client.js
+++ b/dist/amd/debug-telemetry-client.js
@@ -10,12 +10,13 @@ var __extends = (this && this.__extends) || (function () {
 })();
 define(["require", "exports", "aurelia-logging", "./telemetry-client"], function (require, exports, aurelia_logging_1, telemetry_client_1) {
     "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
     var levelMap = new Map();
     levelMap.set(aurelia_logging_1.logLevel.debug, 'DEBUG');
     levelMap.set(aurelia_logging_1.logLevel.info, 'INFO');
     levelMap.set(aurelia_logging_1.logLevel.warn, 'WARN');
     levelMap.set(aurelia_logging_1.logLevel.error, 'ERROR');
-    var DebugTelemetryClient = (function (_super) {
+    var DebugTelemetryClient = /** @class */ (function (_super) {
         __extends(DebugTelemetryClient, _super);
         function DebugTelemetryClient(console) {
             var _this = _super.call(this) || this;
@@ -36,8 +37,8 @@ define(["require", "exports", "aurelia-logging", "./telemetry-client"], function
             for (var _i = 2; _i < arguments.length; _i++) {
                 args[_i - 2] = arguments[_i];
             }
-            (_a = this.console).log.apply(_a, ["Log [" + levelMap.get(level) + "]: " + message].concat(args));
             var _a;
+            (_a = this.console).log.apply(_a, ["Log [" + levelMap.get(level) + "]: " + message].concat(args));
         };
         return DebugTelemetryClient;
     }(telemetry_client_1.TelemetryClient));

--- a/dist/amd/global-error-tracker.d.ts
+++ b/dist/amd/global-error-tracker.d.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from './telemetry-client';
 export declare class GlobalErrorTracker {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     private window;
     constructor(telemetryClient: TelemetryClient, w?: Window);
     activate(): void;

--- a/dist/amd/global-error-tracker.js
+++ b/dist/amd/global-error-tracker.js
@@ -1,6 +1,7 @@
 define(["require", "exports", "./telemetry-client"], function (require, exports, telemetry_client_1) {
     "use strict";
-    var GlobalErrorTracker = (function () {
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var GlobalErrorTracker = /** @class */ (function () {
         function GlobalErrorTracker(telemetryClient, w) {
             var _this = this;
             this.telemetryClient = telemetryClient;
@@ -19,8 +20,8 @@ define(["require", "exports", "./telemetry-client"], function (require, exports,
                 this.window.removeEventListener('error', this.onUnhandledError);
             }
         };
+        GlobalErrorTracker.inject = [telemetry_client_1.TelemetryClient];
         return GlobalErrorTracker;
     }());
-    GlobalErrorTracker.inject = [telemetry_client_1.TelemetryClient];
     exports.GlobalErrorTracker = GlobalErrorTracker;
 });

--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -12,7 +12,7 @@ define(["require", "exports", "./configuration", "./debug-telemetry-client", "./
     __export(telemetry_client_1);
     __export(track_event_binding_behavior_1);
     function configure(aurelia, callback) {
-        aurelia.globalResources(aurelia_framework_1.PLATFORM.moduleName['./track-event-binding-behavior']);
+        aurelia.globalResources([aurelia_framework_1.PLATFORM.moduleName('./track-event-binding-behavior')]);
         var builder = new configuration_2.ConfigurationBuilderImpl();
         if (callback) {
             callback(builder);

--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -3,6 +3,7 @@ define(["require", "exports", "./configuration", "./debug-telemetry-client", "./
     function __export(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
     }
+    Object.defineProperty(exports, "__esModule", { value: true });
     __export(configuration_1);
     __export(debug_telemetry_client_1);
     __export(global_error_tracker_1);
@@ -11,7 +12,7 @@ define(["require", "exports", "./configuration", "./debug-telemetry-client", "./
     __export(telemetry_client_1);
     __export(track_event_binding_behavior_1);
     function configure(aurelia, callback) {
-        aurelia.globalResources(['./track-event-binding-behavior']);
+        aurelia.globalResources(aurelia_framework_1.PLATFORM.moduleName['./track-event-binding-behavior']);
         var builder = new configuration_2.ConfigurationBuilderImpl();
         if (callback) {
             callback(builder);

--- a/dist/amd/log-appender.d.ts
+++ b/dist/amd/log-appender.d.ts
@@ -2,7 +2,7 @@ import { Appender, Logger } from 'aurelia-logging';
 import { TelemetryClient } from './telemetry-client';
 export declare class LogAppender implements Appender {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     constructor(telemetryClient: TelemetryClient);
     debug(logger: Logger, message: string, ...rest: any[]): void;
     info(logger: Logger, message: string, ...rest: any[]): void;

--- a/dist/amd/log-appender.js
+++ b/dist/amd/log-appender.js
@@ -1,6 +1,7 @@
 define(["require", "exports", "aurelia-logging", "./telemetry-client"], function (require, exports, aurelia_logging_1, telemetry_client_1) {
     "use strict";
-    var LogAppender = (function () {
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var LogAppender = /** @class */ (function () {
         function LogAppender(telemetryClient) {
             this.telemetryClient = telemetryClient;
         }
@@ -9,35 +10,35 @@ define(["require", "exports", "aurelia-logging", "./telemetry-client"], function
             for (var _i = 2; _i < arguments.length; _i++) {
                 rest[_i - 2] = arguments[_i];
             }
-            (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.debug].concat(rest));
             var _a;
+            (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.debug].concat(rest));
         };
         LogAppender.prototype.info = function (logger, message) {
             var rest = [];
             for (var _i = 2; _i < arguments.length; _i++) {
                 rest[_i - 2] = arguments[_i];
             }
-            (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.info].concat(rest));
             var _a;
+            (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.info].concat(rest));
         };
         LogAppender.prototype.warn = function (logger, message) {
             var rest = [];
             for (var _i = 2; _i < arguments.length; _i++) {
                 rest[_i - 2] = arguments[_i];
             }
-            (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.warn].concat(rest));
             var _a;
+            (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.warn].concat(rest));
         };
         LogAppender.prototype.error = function (logger, message) {
             var rest = [];
             for (var _i = 2; _i < arguments.length; _i++) {
                 rest[_i - 2] = arguments[_i];
             }
-            (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.error].concat(rest));
             var _a;
+            (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.error].concat(rest));
         };
+        LogAppender.inject = [telemetry_client_1.TelemetryClient];
         return LogAppender;
     }());
-    LogAppender.inject = [telemetry_client_1.TelemetryClient];
     exports.LogAppender = LogAppender;
 });

--- a/dist/amd/page-view-tracker.js
+++ b/dist/amd/page-view-tracker.js
@@ -1,6 +1,7 @@
 define(["require", "exports", "aurelia-event-aggregator", "./telemetry-client"], function (require, exports, aurelia_event_aggregator_1, telemetry_client_1) {
     "use strict";
-    var PageViewTracker = (function () {
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var PageViewTracker = /** @class */ (function () {
         function PageViewTracker(eventAggregator, telemetryClient) {
             var _this = this;
             this.eventAggregator = eventAggregator;
@@ -23,8 +24,8 @@ define(["require", "exports", "aurelia-event-aggregator", "./telemetry-client"],
             this.eventSubscriptions.forEach(function (s) { return s.dispose(); });
             this.eventSubscriptions = [];
         };
+        PageViewTracker.inject = [aurelia_event_aggregator_1.EventAggregator, telemetry_client_1.TelemetryClient];
         return PageViewTracker;
     }());
-    PageViewTracker.inject = [aurelia_event_aggregator_1.EventAggregator, telemetry_client_1.TelemetryClient];
     exports.PageViewTracker = PageViewTracker;
 });

--- a/dist/amd/telemetry-client.js
+++ b/dist/amd/telemetry-client.js
@@ -1,5 +1,6 @@
 define(["require", "exports"], function (require, exports) {
     "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
     var warned = false;
     function warnNoImplementation() {
         if (!warned) {
@@ -7,7 +8,7 @@ define(["require", "exports"], function (require, exports) {
             warned = true;
         }
     }
-    var TelemetryClient = (function () {
+    var TelemetryClient = /** @class */ (function () {
         function TelemetryClient() {
         }
         TelemetryClient.prototype.trackPageView = function (path) {

--- a/dist/amd/track-event-binding-behavior.d.ts
+++ b/dist/amd/track-event-binding-behavior.d.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from './telemetry-client';
 export declare class TrackEventBindingBehavior {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     constructor(telemetryClient: TelemetryClient);
     bind(binding: any, scope: any, name: string, properties?: {
         [key: string]: any;

--- a/dist/amd/track-event-binding-behavior.js
+++ b/dist/amd/track-event-binding-behavior.js
@@ -1,6 +1,7 @@
 define(["require", "exports", "./telemetry-client"], function (require, exports, telemetry_client_1) {
     "use strict";
-    var TrackEventBindingBehavior = (function () {
+    Object.defineProperty(exports, "__esModule", { value: true });
+    var TrackEventBindingBehavior = /** @class */ (function () {
         function TrackEventBindingBehavior(telemetryClient) {
             this.telemetryClient = telemetryClient;
         }
@@ -20,8 +21,8 @@ define(["require", "exports", "./telemetry-client"], function (require, exports,
             binding.callSource = binding.standardCallSource;
             binding.standardCallSource = null;
         };
+        TrackEventBindingBehavior.inject = [telemetry_client_1.TelemetryClient];
         return TrackEventBindingBehavior;
     }());
-    TrackEventBindingBehavior.inject = [telemetry_client_1.TelemetryClient];
     exports.TrackEventBindingBehavior = TrackEventBindingBehavior;
 });

--- a/dist/commonjs/configuration.js
+++ b/dist/commonjs/configuration.js
@@ -1,5 +1,6 @@
 "use strict";
-var ConfigurationBuilderImpl = (function () {
+Object.defineProperty(exports, "__esModule", { value: true });
+var ConfigurationBuilderImpl = /** @class */ (function () {
     function ConfigurationBuilderImpl() {
         this.doTrackLogs = false;
         this.doTrackGlobalErrors = false;

--- a/dist/commonjs/debug-telemetry-client.js
+++ b/dist/commonjs/debug-telemetry-client.js
@@ -9,6 +9,7 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+Object.defineProperty(exports, "__esModule", { value: true });
 var aurelia_logging_1 = require("aurelia-logging");
 var telemetry_client_1 = require("./telemetry-client");
 var levelMap = new Map();
@@ -16,7 +17,7 @@ levelMap.set(aurelia_logging_1.logLevel.debug, 'DEBUG');
 levelMap.set(aurelia_logging_1.logLevel.info, 'INFO');
 levelMap.set(aurelia_logging_1.logLevel.warn, 'WARN');
 levelMap.set(aurelia_logging_1.logLevel.error, 'ERROR');
-var DebugTelemetryClient = (function (_super) {
+var DebugTelemetryClient = /** @class */ (function (_super) {
     __extends(DebugTelemetryClient, _super);
     function DebugTelemetryClient(console) {
         var _this = _super.call(this) || this;
@@ -37,8 +38,8 @@ var DebugTelemetryClient = (function (_super) {
         for (var _i = 2; _i < arguments.length; _i++) {
             args[_i - 2] = arguments[_i];
         }
-        (_a = this.console).log.apply(_a, ["Log [" + levelMap.get(level) + "]: " + message].concat(args));
         var _a;
+        (_a = this.console).log.apply(_a, ["Log [" + levelMap.get(level) + "]: " + message].concat(args));
     };
     return DebugTelemetryClient;
 }(telemetry_client_1.TelemetryClient));

--- a/dist/commonjs/global-error-tracker.d.ts
+++ b/dist/commonjs/global-error-tracker.d.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from './telemetry-client';
 export declare class GlobalErrorTracker {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     private window;
     constructor(telemetryClient: TelemetryClient, w?: Window);
     activate(): void;

--- a/dist/commonjs/global-error-tracker.js
+++ b/dist/commonjs/global-error-tracker.js
@@ -1,6 +1,7 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var telemetry_client_1 = require("./telemetry-client");
-var GlobalErrorTracker = (function () {
+var GlobalErrorTracker = /** @class */ (function () {
     function GlobalErrorTracker(telemetryClient, w) {
         var _this = this;
         this.telemetryClient = telemetryClient;
@@ -19,7 +20,7 @@ var GlobalErrorTracker = (function () {
             this.window.removeEventListener('error', this.onUnhandledError);
         }
     };
+    GlobalErrorTracker.inject = [telemetry_client_1.TelemetryClient];
     return GlobalErrorTracker;
 }());
-GlobalErrorTracker.inject = [telemetry_client_1.TelemetryClient];
 exports.GlobalErrorTracker = GlobalErrorTracker;

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -2,6 +2,7 @@
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
+Object.defineProperty(exports, "__esModule", { value: true });
 __export(require("./configuration"));
 __export(require("./debug-telemetry-client"));
 __export(require("./global-error-tracker"));
@@ -15,7 +16,7 @@ var log_appender_1 = require("./log-appender");
 var global_error_tracker_1 = require("./global-error-tracker");
 var page_view_tracker_1 = require("./page-view-tracker");
 function configure(aurelia, callback) {
-    aurelia.globalResources(['./track-event-binding-behavior']);
+    aurelia.globalResources(aurelia_framework_1.PLATFORM.moduleName['./track-event-binding-behavior']);
     var builder = new configuration_1.ConfigurationBuilderImpl();
     if (callback) {
         callback(builder);

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -16,7 +16,7 @@ var log_appender_1 = require("./log-appender");
 var global_error_tracker_1 = require("./global-error-tracker");
 var page_view_tracker_1 = require("./page-view-tracker");
 function configure(aurelia, callback) {
-    aurelia.globalResources(aurelia_framework_1.PLATFORM.moduleName['./track-event-binding-behavior']);
+    aurelia.globalResources([aurelia_framework_1.PLATFORM.moduleName('./track-event-binding-behavior')]);
     var builder = new configuration_1.ConfigurationBuilderImpl();
     if (callback) {
         callback(builder);

--- a/dist/commonjs/log-appender.d.ts
+++ b/dist/commonjs/log-appender.d.ts
@@ -2,7 +2,7 @@ import { Appender, Logger } from 'aurelia-logging';
 import { TelemetryClient } from './telemetry-client';
 export declare class LogAppender implements Appender {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     constructor(telemetryClient: TelemetryClient);
     debug(logger: Logger, message: string, ...rest: any[]): void;
     info(logger: Logger, message: string, ...rest: any[]): void;

--- a/dist/commonjs/log-appender.js
+++ b/dist/commonjs/log-appender.js
@@ -1,7 +1,8 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var aurelia_logging_1 = require("aurelia-logging");
 var telemetry_client_1 = require("./telemetry-client");
-var LogAppender = (function () {
+var LogAppender = /** @class */ (function () {
     function LogAppender(telemetryClient) {
         this.telemetryClient = telemetryClient;
     }
@@ -10,34 +11,34 @@ var LogAppender = (function () {
         for (var _i = 2; _i < arguments.length; _i++) {
             rest[_i - 2] = arguments[_i];
         }
-        (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.debug].concat(rest));
         var _a;
+        (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.debug].concat(rest));
     };
     LogAppender.prototype.info = function (logger, message) {
         var rest = [];
         for (var _i = 2; _i < arguments.length; _i++) {
             rest[_i - 2] = arguments[_i];
         }
-        (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.info].concat(rest));
         var _a;
+        (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.info].concat(rest));
     };
     LogAppender.prototype.warn = function (logger, message) {
         var rest = [];
         for (var _i = 2; _i < arguments.length; _i++) {
             rest[_i - 2] = arguments[_i];
         }
-        (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.warn].concat(rest));
         var _a;
+        (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.warn].concat(rest));
     };
     LogAppender.prototype.error = function (logger, message) {
         var rest = [];
         for (var _i = 2; _i < arguments.length; _i++) {
             rest[_i - 2] = arguments[_i];
         }
-        (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.error].concat(rest));
         var _a;
+        (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.error].concat(rest));
     };
+    LogAppender.inject = [telemetry_client_1.TelemetryClient];
     return LogAppender;
 }());
-LogAppender.inject = [telemetry_client_1.TelemetryClient];
 exports.LogAppender = LogAppender;

--- a/dist/commonjs/page-view-tracker.js
+++ b/dist/commonjs/page-view-tracker.js
@@ -1,7 +1,8 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var aurelia_event_aggregator_1 = require("aurelia-event-aggregator");
 var telemetry_client_1 = require("./telemetry-client");
-var PageViewTracker = (function () {
+var PageViewTracker = /** @class */ (function () {
     function PageViewTracker(eventAggregator, telemetryClient) {
         var _this = this;
         this.eventAggregator = eventAggregator;
@@ -24,7 +25,7 @@ var PageViewTracker = (function () {
         this.eventSubscriptions.forEach(function (s) { return s.dispose(); });
         this.eventSubscriptions = [];
     };
+    PageViewTracker.inject = [aurelia_event_aggregator_1.EventAggregator, telemetry_client_1.TelemetryClient];
     return PageViewTracker;
 }());
-PageViewTracker.inject = [aurelia_event_aggregator_1.EventAggregator, telemetry_client_1.TelemetryClient];
 exports.PageViewTracker = PageViewTracker;

--- a/dist/commonjs/telemetry-client.js
+++ b/dist/commonjs/telemetry-client.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var warned = false;
 function warnNoImplementation() {
     if (!warned) {
@@ -6,7 +7,7 @@ function warnNoImplementation() {
         warned = true;
     }
 }
-var TelemetryClient = (function () {
+var TelemetryClient = /** @class */ (function () {
     function TelemetryClient() {
     }
     TelemetryClient.prototype.trackPageView = function (path) {

--- a/dist/commonjs/track-event-binding-behavior.d.ts
+++ b/dist/commonjs/track-event-binding-behavior.d.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from './telemetry-client';
 export declare class TrackEventBindingBehavior {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     constructor(telemetryClient: TelemetryClient);
     bind(binding: any, scope: any, name: string, properties?: {
         [key: string]: any;

--- a/dist/commonjs/track-event-binding-behavior.js
+++ b/dist/commonjs/track-event-binding-behavior.js
@@ -1,6 +1,7 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 var telemetry_client_1 = require("./telemetry-client");
-var TrackEventBindingBehavior = (function () {
+var TrackEventBindingBehavior = /** @class */ (function () {
     function TrackEventBindingBehavior(telemetryClient) {
         this.telemetryClient = telemetryClient;
     }
@@ -20,7 +21,7 @@ var TrackEventBindingBehavior = (function () {
         binding.callSource = binding.standardCallSource;
         binding.standardCallSource = null;
     };
+    TrackEventBindingBehavior.inject = [telemetry_client_1.TelemetryClient];
     return TrackEventBindingBehavior;
 }());
-TrackEventBindingBehavior.inject = [telemetry_client_1.TelemetryClient];
 exports.TrackEventBindingBehavior = TrackEventBindingBehavior;

--- a/dist/es2015/configuration.js
+++ b/dist/es2015/configuration.js
@@ -1,4 +1,4 @@
-var ConfigurationBuilderImpl = (function () {
+var ConfigurationBuilderImpl = /** @class */ (function () {
     function ConfigurationBuilderImpl() {
         this.doTrackLogs = false;
         this.doTrackGlobalErrors = false;

--- a/dist/es2015/debug-telemetry-client.js
+++ b/dist/es2015/debug-telemetry-client.js
@@ -15,7 +15,7 @@ levelMap.set(logLevel.debug, 'DEBUG');
 levelMap.set(logLevel.info, 'INFO');
 levelMap.set(logLevel.warn, 'WARN');
 levelMap.set(logLevel.error, 'ERROR');
-var DebugTelemetryClient = (function (_super) {
+var DebugTelemetryClient = /** @class */ (function (_super) {
     __extends(DebugTelemetryClient, _super);
     function DebugTelemetryClient(console) {
         var _this = _super.call(this) || this;
@@ -36,8 +36,8 @@ var DebugTelemetryClient = (function (_super) {
         for (var _i = 2; _i < arguments.length; _i++) {
             args[_i - 2] = arguments[_i];
         }
-        (_a = this.console).log.apply(_a, ["Log [" + levelMap.get(level) + "]: " + message].concat(args));
         var _a;
+        (_a = this.console).log.apply(_a, ["Log [" + levelMap.get(level) + "]: " + message].concat(args));
     };
     return DebugTelemetryClient;
 }(TelemetryClient));

--- a/dist/es2015/global-error-tracker.d.ts
+++ b/dist/es2015/global-error-tracker.d.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from './telemetry-client';
 export declare class GlobalErrorTracker {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     private window;
     constructor(telemetryClient: TelemetryClient, w?: Window);
     activate(): void;

--- a/dist/es2015/global-error-tracker.js
+++ b/dist/es2015/global-error-tracker.js
@@ -1,5 +1,5 @@
 import { TelemetryClient } from './telemetry-client';
-var GlobalErrorTracker = (function () {
+var GlobalErrorTracker = /** @class */ (function () {
     function GlobalErrorTracker(telemetryClient, w) {
         var _this = this;
         this.telemetryClient = telemetryClient;
@@ -18,7 +18,7 @@ var GlobalErrorTracker = (function () {
             this.window.removeEventListener('error', this.onUnhandledError);
         }
     };
+    GlobalErrorTracker.inject = [TelemetryClient];
     return GlobalErrorTracker;
 }());
 export { GlobalErrorTracker };
-GlobalErrorTracker.inject = [TelemetryClient];

--- a/dist/es2015/index.js
+++ b/dist/es2015/index.js
@@ -11,7 +11,7 @@ import { LogAppender } from './log-appender';
 import { GlobalErrorTracker } from './global-error-tracker';
 import { PageViewTracker } from './page-view-tracker';
 export function configure(aurelia, callback) {
-    aurelia.globalResources(PLATFORM.moduleName['./track-event-binding-behavior']);
+    aurelia.globalResources([PLATFORM.moduleName('./track-event-binding-behavior')]);
     var builder = new ConfigurationBuilderImpl();
     if (callback) {
         callback(builder);

--- a/dist/es2015/index.js
+++ b/dist/es2015/index.js
@@ -5,13 +5,13 @@ export * from './log-appender';
 export * from './page-view-tracker';
 export * from './telemetry-client';
 export * from './track-event-binding-behavior';
-import { LogManager } from 'aurelia-framework';
+import { LogManager, PLATFORM } from 'aurelia-framework';
 import { ConfigurationBuilderImpl } from './configuration';
 import { LogAppender } from './log-appender';
 import { GlobalErrorTracker } from './global-error-tracker';
 import { PageViewTracker } from './page-view-tracker';
 export function configure(aurelia, callback) {
-    aurelia.globalResources(['./track-event-binding-behavior']);
+    aurelia.globalResources(PLATFORM.moduleName['./track-event-binding-behavior']);
     var builder = new ConfigurationBuilderImpl();
     if (callback) {
         callback(builder);

--- a/dist/es2015/log-appender.d.ts
+++ b/dist/es2015/log-appender.d.ts
@@ -2,7 +2,7 @@ import { Appender, Logger } from 'aurelia-logging';
 import { TelemetryClient } from './telemetry-client';
 export declare class LogAppender implements Appender {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     constructor(telemetryClient: TelemetryClient);
     debug(logger: Logger, message: string, ...rest: any[]): void;
     info(logger: Logger, message: string, ...rest: any[]): void;

--- a/dist/es2015/log-appender.js
+++ b/dist/es2015/log-appender.js
@@ -1,6 +1,6 @@
 import { logLevel } from 'aurelia-logging';
 import { TelemetryClient } from './telemetry-client';
-var LogAppender = (function () {
+var LogAppender = /** @class */ (function () {
     function LogAppender(telemetryClient) {
         this.telemetryClient = telemetryClient;
     }
@@ -9,34 +9,34 @@ var LogAppender = (function () {
         for (var _i = 2; _i < arguments.length; _i++) {
             rest[_i - 2] = arguments[_i];
         }
-        (_a = this.telemetryClient).trackLog.apply(_a, [message, logLevel.debug].concat(rest));
         var _a;
+        (_a = this.telemetryClient).trackLog.apply(_a, [message, logLevel.debug].concat(rest));
     };
     LogAppender.prototype.info = function (logger, message) {
         var rest = [];
         for (var _i = 2; _i < arguments.length; _i++) {
             rest[_i - 2] = arguments[_i];
         }
-        (_a = this.telemetryClient).trackLog.apply(_a, [message, logLevel.info].concat(rest));
         var _a;
+        (_a = this.telemetryClient).trackLog.apply(_a, [message, logLevel.info].concat(rest));
     };
     LogAppender.prototype.warn = function (logger, message) {
         var rest = [];
         for (var _i = 2; _i < arguments.length; _i++) {
             rest[_i - 2] = arguments[_i];
         }
-        (_a = this.telemetryClient).trackLog.apply(_a, [message, logLevel.warn].concat(rest));
         var _a;
+        (_a = this.telemetryClient).trackLog.apply(_a, [message, logLevel.warn].concat(rest));
     };
     LogAppender.prototype.error = function (logger, message) {
         var rest = [];
         for (var _i = 2; _i < arguments.length; _i++) {
             rest[_i - 2] = arguments[_i];
         }
-        (_a = this.telemetryClient).trackLog.apply(_a, [message, logLevel.error].concat(rest));
         var _a;
+        (_a = this.telemetryClient).trackLog.apply(_a, [message, logLevel.error].concat(rest));
     };
+    LogAppender.inject = [TelemetryClient];
     return LogAppender;
 }());
 export { LogAppender };
-LogAppender.inject = [TelemetryClient];

--- a/dist/es2015/page-view-tracker.js
+++ b/dist/es2015/page-view-tracker.js
@@ -1,6 +1,6 @@
 import { EventAggregator } from 'aurelia-event-aggregator';
 import { TelemetryClient } from './telemetry-client';
-var PageViewTracker = (function () {
+var PageViewTracker = /** @class */ (function () {
     function PageViewTracker(eventAggregator, telemetryClient) {
         var _this = this;
         this.eventAggregator = eventAggregator;
@@ -23,7 +23,7 @@ var PageViewTracker = (function () {
         this.eventSubscriptions.forEach(function (s) { return s.dispose(); });
         this.eventSubscriptions = [];
     };
+    PageViewTracker.inject = [EventAggregator, TelemetryClient];
     return PageViewTracker;
 }());
 export { PageViewTracker };
-PageViewTracker.inject = [EventAggregator, TelemetryClient];

--- a/dist/es2015/telemetry-client.js
+++ b/dist/es2015/telemetry-client.js
@@ -5,7 +5,7 @@ function warnNoImplementation() {
         warned = true;
     }
 }
-var TelemetryClient = (function () {
+var TelemetryClient = /** @class */ (function () {
     function TelemetryClient() {
     }
     TelemetryClient.prototype.trackPageView = function (path) {

--- a/dist/es2015/track-event-binding-behavior.d.ts
+++ b/dist/es2015/track-event-binding-behavior.d.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from './telemetry-client';
 export declare class TrackEventBindingBehavior {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     constructor(telemetryClient: TelemetryClient);
     bind(binding: any, scope: any, name: string, properties?: {
         [key: string]: any;

--- a/dist/es2015/track-event-binding-behavior.js
+++ b/dist/es2015/track-event-binding-behavior.js
@@ -1,5 +1,5 @@
 import { TelemetryClient } from './telemetry-client';
-var TrackEventBindingBehavior = (function () {
+var TrackEventBindingBehavior = /** @class */ (function () {
     function TrackEventBindingBehavior(telemetryClient) {
         this.telemetryClient = telemetryClient;
     }
@@ -19,7 +19,7 @@ var TrackEventBindingBehavior = (function () {
         binding.callSource = binding.standardCallSource;
         binding.standardCallSource = null;
     };
+    TrackEventBindingBehavior.inject = [TelemetryClient];
     return TrackEventBindingBehavior;
 }());
 export { TrackEventBindingBehavior };
-TrackEventBindingBehavior.inject = [TelemetryClient];

--- a/dist/system/configuration.js
+++ b/dist/system/configuration.js
@@ -1,11 +1,11 @@
 System.register([], function (exports_1, context_1) {
     "use strict";
-    var __moduleName = context_1 && context_1.id;
     var ConfigurationBuilderImpl;
+    var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
         execute: function () {
-            ConfigurationBuilderImpl = (function () {
+            ConfigurationBuilderImpl = /** @class */ (function () {
                 function ConfigurationBuilderImpl() {
                     this.doTrackLogs = false;
                     this.doTrackGlobalErrors = false;

--- a/dist/system/debug-telemetry-client.js
+++ b/dist/system/debug-telemetry-client.js
@@ -10,8 +10,8 @@ System.register(["aurelia-logging", "./telemetry-client"], function (exports_1, 
             d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
         };
     })();
-    var __moduleName = context_1 && context_1.id;
     var aurelia_logging_1, telemetry_client_1, levelMap, DebugTelemetryClient;
+    var __moduleName = context_1 && context_1.id;
     return {
         setters: [
             function (aurelia_logging_1_1) {
@@ -27,7 +27,7 @@ System.register(["aurelia-logging", "./telemetry-client"], function (exports_1, 
             levelMap.set(aurelia_logging_1.logLevel.info, 'INFO');
             levelMap.set(aurelia_logging_1.logLevel.warn, 'WARN');
             levelMap.set(aurelia_logging_1.logLevel.error, 'ERROR');
-            DebugTelemetryClient = (function (_super) {
+            DebugTelemetryClient = /** @class */ (function (_super) {
                 __extends(DebugTelemetryClient, _super);
                 function DebugTelemetryClient(console) {
                     var _this = _super.call(this) || this;
@@ -48,8 +48,8 @@ System.register(["aurelia-logging", "./telemetry-client"], function (exports_1, 
                     for (var _i = 2; _i < arguments.length; _i++) {
                         args[_i - 2] = arguments[_i];
                     }
-                    (_a = this.console).log.apply(_a, ["Log [" + levelMap.get(level) + "]: " + message].concat(args));
                     var _a;
+                    (_a = this.console).log.apply(_a, ["Log [" + levelMap.get(level) + "]: " + message].concat(args));
                 };
                 return DebugTelemetryClient;
             }(telemetry_client_1.TelemetryClient));

--- a/dist/system/global-error-tracker.d.ts
+++ b/dist/system/global-error-tracker.d.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from './telemetry-client';
 export declare class GlobalErrorTracker {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     private window;
     constructor(telemetryClient: TelemetryClient, w?: Window);
     activate(): void;

--- a/dist/system/global-error-tracker.js
+++ b/dist/system/global-error-tracker.js
@@ -1,7 +1,7 @@
 System.register(["./telemetry-client"], function (exports_1, context_1) {
     "use strict";
-    var __moduleName = context_1 && context_1.id;
     var telemetry_client_1, GlobalErrorTracker;
+    var __moduleName = context_1 && context_1.id;
     return {
         setters: [
             function (telemetry_client_1_1) {
@@ -9,7 +9,7 @@ System.register(["./telemetry-client"], function (exports_1, context_1) {
             }
         ],
         execute: function () {
-            GlobalErrorTracker = (function () {
+            GlobalErrorTracker = /** @class */ (function () {
                 function GlobalErrorTracker(telemetryClient, w) {
                     var _this = this;
                     this.telemetryClient = telemetryClient;
@@ -28,9 +28,9 @@ System.register(["./telemetry-client"], function (exports_1, context_1) {
                         this.window.removeEventListener('error', this.onUnhandledError);
                     }
                 };
+                GlobalErrorTracker.inject = [telemetry_client_1.TelemetryClient];
                 return GlobalErrorTracker;
             }());
-            GlobalErrorTracker.inject = [telemetry_client_1.TelemetryClient];
             exports_1("GlobalErrorTracker", GlobalErrorTracker);
         }
     };

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -1,8 +1,9 @@
 System.register(["./configuration", "./debug-telemetry-client", "./global-error-tracker", "./log-appender", "./page-view-tracker", "./telemetry-client", "./track-event-binding-behavior", "aurelia-framework"], function (exports_1, context_1) {
     "use strict";
+    var aurelia_framework_1, configuration_1, log_appender_1, global_error_tracker_1, page_view_tracker_1;
     var __moduleName = context_1 && context_1.id;
     function configure(aurelia, callback) {
-        aurelia.globalResources(['./track-event-binding-behavior']);
+        aurelia.globalResources(aurelia_framework_1.PLATFORM.moduleName['./track-event-binding-behavior']);
         var builder = new configuration_1.ConfigurationBuilderImpl();
         if (callback) {
             callback(builder);
@@ -19,7 +20,6 @@ System.register(["./configuration", "./debug-telemetry-client", "./global-error-
         }
     }
     exports_1("configure", configure);
-    var aurelia_framework_1, configuration_1, log_appender_1, global_error_tracker_1, page_view_tracker_1;
     var exportedNames_1 = {
         "configure": true
     };

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -3,7 +3,7 @@ System.register(["./configuration", "./debug-telemetry-client", "./global-error-
     var aurelia_framework_1, configuration_1, log_appender_1, global_error_tracker_1, page_view_tracker_1;
     var __moduleName = context_1 && context_1.id;
     function configure(aurelia, callback) {
-        aurelia.globalResources(aurelia_framework_1.PLATFORM.moduleName['./track-event-binding-behavior']);
+        aurelia.globalResources([aurelia_framework_1.PLATFORM.moduleName('./track-event-binding-behavior')]);
         var builder = new configuration_1.ConfigurationBuilderImpl();
         if (callback) {
             callback(builder);

--- a/dist/system/log-appender.d.ts
+++ b/dist/system/log-appender.d.ts
@@ -2,7 +2,7 @@ import { Appender, Logger } from 'aurelia-logging';
 import { TelemetryClient } from './telemetry-client';
 export declare class LogAppender implements Appender {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     constructor(telemetryClient: TelemetryClient);
     debug(logger: Logger, message: string, ...rest: any[]): void;
     info(logger: Logger, message: string, ...rest: any[]): void;

--- a/dist/system/log-appender.js
+++ b/dist/system/log-appender.js
@@ -1,7 +1,7 @@
 System.register(["aurelia-logging", "./telemetry-client"], function (exports_1, context_1) {
     "use strict";
-    var __moduleName = context_1 && context_1.id;
     var aurelia_logging_1, telemetry_client_1, LogAppender;
+    var __moduleName = context_1 && context_1.id;
     return {
         setters: [
             function (aurelia_logging_1_1) {
@@ -12,7 +12,7 @@ System.register(["aurelia-logging", "./telemetry-client"], function (exports_1, 
             }
         ],
         execute: function () {
-            LogAppender = (function () {
+            LogAppender = /** @class */ (function () {
                 function LogAppender(telemetryClient) {
                     this.telemetryClient = telemetryClient;
                 }
@@ -21,36 +21,36 @@ System.register(["aurelia-logging", "./telemetry-client"], function (exports_1, 
                     for (var _i = 2; _i < arguments.length; _i++) {
                         rest[_i - 2] = arguments[_i];
                     }
-                    (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.debug].concat(rest));
                     var _a;
+                    (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.debug].concat(rest));
                 };
                 LogAppender.prototype.info = function (logger, message) {
                     var rest = [];
                     for (var _i = 2; _i < arguments.length; _i++) {
                         rest[_i - 2] = arguments[_i];
                     }
-                    (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.info].concat(rest));
                     var _a;
+                    (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.info].concat(rest));
                 };
                 LogAppender.prototype.warn = function (logger, message) {
                     var rest = [];
                     for (var _i = 2; _i < arguments.length; _i++) {
                         rest[_i - 2] = arguments[_i];
                     }
-                    (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.warn].concat(rest));
                     var _a;
+                    (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.warn].concat(rest));
                 };
                 LogAppender.prototype.error = function (logger, message) {
                     var rest = [];
                     for (var _i = 2; _i < arguments.length; _i++) {
                         rest[_i - 2] = arguments[_i];
                     }
-                    (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.error].concat(rest));
                     var _a;
+                    (_a = this.telemetryClient).trackLog.apply(_a, [message, aurelia_logging_1.logLevel.error].concat(rest));
                 };
+                LogAppender.inject = [telemetry_client_1.TelemetryClient];
                 return LogAppender;
             }());
-            LogAppender.inject = [telemetry_client_1.TelemetryClient];
             exports_1("LogAppender", LogAppender);
         }
     };

--- a/dist/system/page-view-tracker.js
+++ b/dist/system/page-view-tracker.js
@@ -1,7 +1,7 @@
 System.register(["aurelia-event-aggregator", "./telemetry-client"], function (exports_1, context_1) {
     "use strict";
-    var __moduleName = context_1 && context_1.id;
     var aurelia_event_aggregator_1, telemetry_client_1, PageViewTracker;
+    var __moduleName = context_1 && context_1.id;
     return {
         setters: [
             function (aurelia_event_aggregator_1_1) {
@@ -12,7 +12,7 @@ System.register(["aurelia-event-aggregator", "./telemetry-client"], function (ex
             }
         ],
         execute: function () {
-            PageViewTracker = (function () {
+            PageViewTracker = /** @class */ (function () {
                 function PageViewTracker(eventAggregator, telemetryClient) {
                     var _this = this;
                     this.eventAggregator = eventAggregator;
@@ -35,9 +35,9 @@ System.register(["aurelia-event-aggregator", "./telemetry-client"], function (ex
                     this.eventSubscriptions.forEach(function (s) { return s.dispose(); });
                     this.eventSubscriptions = [];
                 };
+                PageViewTracker.inject = [aurelia_event_aggregator_1.EventAggregator, telemetry_client_1.TelemetryClient];
                 return PageViewTracker;
             }());
-            PageViewTracker.inject = [aurelia_event_aggregator_1.EventAggregator, telemetry_client_1.TelemetryClient];
             exports_1("PageViewTracker", PageViewTracker);
         }
     };

--- a/dist/system/telemetry-client.js
+++ b/dist/system/telemetry-client.js
@@ -1,5 +1,6 @@
 System.register([], function (exports_1, context_1) {
     "use strict";
+    var warned, TelemetryClient;
     var __moduleName = context_1 && context_1.id;
     function warnNoImplementation() {
         if (!warned) {
@@ -7,12 +8,11 @@ System.register([], function (exports_1, context_1) {
             warned = true;
         }
     }
-    var warned, TelemetryClient;
     return {
         setters: [],
         execute: function () {
             warned = false;
-            TelemetryClient = (function () {
+            TelemetryClient = /** @class */ (function () {
                 function TelemetryClient() {
                 }
                 TelemetryClient.prototype.trackPageView = function (path) {

--- a/dist/system/track-event-binding-behavior.d.ts
+++ b/dist/system/track-event-binding-behavior.d.ts
@@ -1,7 +1,7 @@
 import { TelemetryClient } from './telemetry-client';
 export declare class TrackEventBindingBehavior {
     private telemetryClient;
-    static inject: typeof TelemetryClient[];
+    static inject: (typeof TelemetryClient)[];
     constructor(telemetryClient: TelemetryClient);
     bind(binding: any, scope: any, name: string, properties?: {
         [key: string]: any;

--- a/dist/system/track-event-binding-behavior.js
+++ b/dist/system/track-event-binding-behavior.js
@@ -1,7 +1,7 @@
 System.register(["./telemetry-client"], function (exports_1, context_1) {
     "use strict";
-    var __moduleName = context_1 && context_1.id;
     var telemetry_client_1, TrackEventBindingBehavior;
+    var __moduleName = context_1 && context_1.id;
     return {
         setters: [
             function (telemetry_client_1_1) {
@@ -9,7 +9,7 @@ System.register(["./telemetry-client"], function (exports_1, context_1) {
             }
         ],
         execute: function () {
-            TrackEventBindingBehavior = (function () {
+            TrackEventBindingBehavior = /** @class */ (function () {
                 function TrackEventBindingBehavior(telemetryClient) {
                     this.telemetryClient = telemetryClient;
                 }
@@ -29,9 +29,9 @@ System.register(["./telemetry-client"], function (exports_1, context_1) {
                     binding.callSource = binding.standardCallSource;
                     binding.standardCallSource = null;
                 };
+                TrackEventBindingBehavior.inject = [telemetry_client_1.TelemetryClient];
                 return TrackEventBindingBehavior;
             }());
-            TrackEventBindingBehavior.inject = [telemetry_client_1.TelemetryClient];
             exports_1("TrackEventBindingBehavior", TrackEventBindingBehavior);
         }
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-telemetry",
-  "version": "1.0.0-beta-1",
+  "version": "1.0.0-beta-2",
   "description": "Telemetry for Aurelia applications.",
   "keywords": [
     "telemetry",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {GlobalErrorTracker} from './global-error-tracker';
 import {PageViewTracker} from './page-view-tracker';
 
 export function configure(aurelia: FrameworkConfiguration, callback?: ((c: ConfigurationBuilder) => void)) {
-  aurelia.globalResources(PLATFORM.moduleName['./track-event-binding-behavior']);
+  aurelia.globalResources([PLATFORM.moduleName('./track-event-binding-behavior')]);
   
   const builder = new ConfigurationBuilderImpl();
   if (callback) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,14 @@ export * from './page-view-tracker';
 export * from './telemetry-client';
 export * from './track-event-binding-behavior';
 
-import {FrameworkConfiguration, LogManager} from 'aurelia-framework';
+import {FrameworkConfiguration, LogManager, PLATFORM} from 'aurelia-framework';
 import {ConfigurationBuilder, ConfigurationBuilderImpl} from './configuration';
 import {LogAppender} from './log-appender';
 import {GlobalErrorTracker} from './global-error-tracker';
 import {PageViewTracker} from './page-view-tracker';
 
 export function configure(aurelia: FrameworkConfiguration, callback?: ((c: ConfigurationBuilder) => void)) {
-  aurelia.globalResources(['./track-event-binding-behavior']);
+  aurelia.globalResources(PLATFORM.moduleName['./track-event-binding-behavior']);
   
   const builder = new ConfigurationBuilderImpl();
   if (callback) {


### PR DESCRIPTION
Hi,
I could not use your plugin together with webpack.
To fix this I have to wrap module references with PLATFORM.moduleName.
This patch is probaby still compatible with Aurelias own bundler.

